### PR TITLE
SqlContext renamed

### DIFF
--- a/Common/Configuration/SQL/SqlContext.cs
+++ b/Common/Configuration/SQL/SqlContext.cs
@@ -6,7 +6,7 @@ namespace Common.Configuration.SQL
     /// Abstract class, describing basic logic for SqlContext.
     /// Getter for Context should be overriden in order to use establish proper connection
     /// </summary>
-    public abstract class SqlContext
+    public abstract class BaseSqlContext
     {
         /// <summary>
         /// Reads configuration file and returns connection string assembled from it


### PR DESCRIPTION
Renamed SqlContext into BaseSqlContext for better code readability in future: for instance, if we will create new child of SqlContext, it will have some bigger name, like CatalogSqlContext. I find it a bit messy, as SqlContext should be used only for inheritance, and will not be used as much as childrem. So it will be better to rename abstract parent into BaseSqlContext right now, and then create SqlContext : BaseSqlContext in each service.